### PR TITLE
Add dashboards for compact block reconstruction metrics

### DIFF
--- a/tools/metrics/dashboards/playlist/compactblock-reconstruction-high-bandwidth.json
+++ b/tools/metrics/dashboards/playlist/compactblock-reconstruction-high-bandwidth.json
@@ -71,12 +71,12 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
+                "color": "green",
                 "value": 0
               },
               {
-                "color": "transparent",
-                "value": 0
+                "color": "red",
+                "value": 80
               }
             ]
           },
@@ -90,7 +90,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 2,
+      "id": 1,
       "options": {
         "legend": {
           "calcs": [],
@@ -100,7 +100,7 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
@@ -111,42 +111,23 @@
             "type": "prometheus",
             "uid": "P1809F7CD0C75ACF3"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(increase(peerobserver_log_compact_block_reconstruction_count{tx_requested=\"false\"}[1d])) by (host)\r\n/ sum(increase(peerobserver_log_compact_block_reconstruction_count[1d])) by (host)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
+          "expr": "sum(increase(peerobserver_log_compact_block_reconstruction_count{bandwidth=\"high\"}[1d])) by (host)\r\n/ (sum(increase(peerobserver_log_compact_block_reconstruction_count[1d])) by (host))",
           "interval": "12h",
-          "legendFormat": "__auto",
+          "legendFormat": "{{host}}",
           "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
-          },
-          "editorMode": "code",
-          "expr": "1 - sum(increase(peerobserver_p2p_message_count{message=\"getblocktxn\", direction=\"outbound\"}[1d])) by (host) / sum(increase(peerobserver_p2p_message_count{message=\"cmpctblock\", direction=\"inbound\"}[1d])) by (host)",
-          "hide": true,
-          "instant": false,
-          "interval": "12h",
-          "legendFormat": "{{host}} approx",
-          "range": true,
-          "refId": "B"
+          "refId": "A"
         }
       ],
-      "title": "Compact block reconstruction without transaction requests per day",
+      "title": "Compact block reconstruction in high-bandwidth per day",
       "type": "timeseries"
     }
   ],
   "preload": false,
   "schemaVersion": 42,
   "tags": [
-    "compact-block",
-    "big-playlist"
+    "big-playlist",
+    "compact-block"
   ],
   "templating": {
     "list": []
@@ -157,8 +138,8 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "[compact-block] Compact block reconstruction without transaction requests",
-  "uid": "adtsyzmbdt0cgc",
-  "version": 13,
+  "title": "[compact-block] Compact block reconstruction in high-bandwidth",
+  "uid": "adbpgdz",
+  "version": 1,
   "weekStart": ""
 }

--- a/tools/metrics/dashboards/playlist/compactblock-reconstruction-time.json
+++ b/tools/metrics/dashboards/playlist/compactblock-reconstruction-time.json
@@ -36,8 +36,6 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
-            "axisSoftMax": 1,
-            "axisSoftMin": 0,
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
@@ -71,16 +69,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
+                "color": "green",
                 "value": 0
               },
               {
-                "color": "transparent",
-                "value": 0
+                "color": "red",
+                "value": 80
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "µs"
         },
         "overrides": []
       },
@@ -90,7 +88,9 @@
         "x": 0,
         "y": 0
       },
-      "id": 2,
+      "id": 1,
+      "interval": "1m",
+      "maxDataPoints": 10000,
       "options": {
         "legend": {
           "calcs": [],
@@ -100,7 +100,7 @@
         },
         "tooltip": {
           "hideZeros": false,
-          "mode": "multi",
+          "mode": "single",
           "sort": "none"
         }
       },
@@ -111,34 +111,14 @@
             "type": "prometheus",
             "uid": "P1809F7CD0C75ACF3"
           },
-          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(increase(peerobserver_log_compact_block_reconstruction_count{tx_requested=\"false\"}[1d])) by (host)\r\n/ sum(increase(peerobserver_log_compact_block_reconstruction_count[1d])) by (host)",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "interval": "12h",
-          "legendFormat": "__auto",
+          "expr": "avg_over_time(\r\n  max by (host) (\r\n    peerobserver_log_compact_block_reconstruction_time\r\n      and\r\n    changes(peerobserver_log_compact_block_reconstruction_count[$__interval]) > 0\r\n  )[1d:]\r\n)",
+          "legendFormat": "{{host}}",
           "range": true,
-          "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "P1809F7CD0C75ACF3"
-          },
-          "editorMode": "code",
-          "expr": "1 - sum(increase(peerobserver_p2p_message_count{message=\"getblocktxn\", direction=\"outbound\"}[1d])) by (host) / sum(increase(peerobserver_p2p_message_count{message=\"cmpctblock\", direction=\"inbound\"}[1d])) by (host)",
-          "hide": true,
-          "instant": false,
-          "interval": "12h",
-          "legendFormat": "{{host}} approx",
-          "range": true,
-          "refId": "B"
+          "refId": "A"
         }
       ],
-      "title": "Compact block reconstruction without transaction requests per day",
+      "title": "Average compact block reconstruction time",
       "type": "timeseries"
     }
   ],
@@ -152,13 +132,13 @@
     "list": []
   },
   "time": {
-    "from": "now-90d",
+    "from": "now-30d",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "[compact-block] Compact block reconstruction without transaction requests",
-  "uid": "adtsyzmbdt0cgc",
-  "version": 13,
+  "title": "[compact-block] Compact block reconstruction time",
+  "uid": "adqvgct",
+  "version": 2,
   "weekStart": ""
 }

--- a/tools/metrics/dashboards/playlist/compactblock-requested-txs-stats.json
+++ b/tools/metrics/dashboards/playlist/compactblock-requested-txs-stats.json
@@ -1,0 +1,417 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "interval": "$per_time",
+      "maxPerRow": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "increase(peerobserver_log_compact_block_reconstruction_requested_bytes[$__interval])",
+          "instant": false,
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "sum"
+        }
+      ],
+      "title": "Size of requested transactions per $per_time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 18,
+      "interval": "$per_time",
+      "maxPerRow": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "increase(peerobserver_log_compact_block_reconstruction_txs_requested[$__interval])",
+          "instant": false,
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "sum"
+        }
+      ],
+      "title": "Number of requested transactions per $per_time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P1809F7CD0C75ACF3"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 19,
+      "interval": "$per_time",
+      "maxPerRow": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P1809F7CD0C75ACF3"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "increase(peerobserver_log_compact_block_reconstruction_txs_extra_pool[$__interval])",
+          "instant": false,
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "sum"
+        }
+      ],
+      "title": "Number of transactions in extra pool per $per_time",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5m",
+  "schemaVersion": 42,
+  "tags": [
+    "big-playlist",
+    "compact-block"
+  ],
+  "templating": {
+    "list": [
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "6h",
+          "value": "6h"
+        },
+        "name": "per_time",
+        "options": [
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": true,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "[compact-block] Requested transactions stats",
+  "uid": "asdfdgsdfgsdfgsredg",
+  "version": 2,
+  "weekStart": ""
+}


### PR DESCRIPTION
This PR is a follow up from #420, it introduces dashboards that shows metrics from it. This was separated from the previous PR to reduce review workload, many comments were made regarding those dashboards on it.

## What this PR does?

- Refactor "Compact block reconstruction without transaction requests" dashboard that actually is an approximation to be an "exact" one ([ref on demo](https://demo.peer.observer/monitoring/d/adtsyzmbdt0cgc/99bfac5?orgId=1&from=now-90d&to=now&timezone=browser));
- Add new dashboards about compact blocks:
  - "Compact block reconstruction in high-bandwidth per day";
  - "Requested transactions stats";
  - "Compact block reconstruction time".

## Dashboards

All screenshots are from my vps running this branch on mainnet.

### Compact block reconstruction without transaction requests per day

This dashboard already existed in the project but it was an approximation using some assumptions from p2p messages, now by watching logs we can be sure of how much of these reconstructions are actually requiring transactions. The yellow line is the "old" approximation, the green one is based on logs -- in the final version, I hide the approximation line. There's quite some difference 👀.

<img width="1245" height="754" alt="image" src="https://github.com/user-attachments/assets/18989315-5b5d-4ed6-977a-a14ced9ff14e" />

### Compact block reconstruction in high-bandwidth per day

Also a simple one, see heuristic in [How do we know if the reconstruction was via low or high-bandwidth connection?](https://github.com/peer-observer/peer-observer/pull/420#how-do-we-know-if-the-reconstruction-was-via-low-or-high-bandwidth-connection).

<img width="1243" height="754" alt="image" src="https://github.com/user-attachments/assets/ea81bb76-3ab8-4caa-9fd1-7db24b28835d" />

### Requested transactions stats

Some statistics about requested transaction that were not in mempool. Each representing the sum in a "per time" range. Size and number of requested transactions, and also number of transactions in extra pool.

<img width="1152" height="1103" alt="Captura de tela_30-6-2026_145956_5 189 165 114" src="https://github.com/user-attachments/assets/3df516db-ff6d-4768-9ca8-6381cb909f2c" />

### Compact block reconstruction time

This dash shows the average time that a block took to make the reconstruction round-trip, it doesn't filter by bandwidth nor with/without transactions.

<img width="1243" height="752" alt="image" src="https://github.com/user-attachments/assets/ce196031-ff69-4f3f-a718-c397c87c185a" />
