### PR TITLE
test(archive): replace fixed sleeps with NATS synchronization

### DIFF
--- a/shared/src/testing/nats_publisher.rs
+++ b/shared/src/testing/nats_publisher.rs
@@ -1,3 +1,7 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+
 pub struct NatsPublisherForTesting {
     client: async_nats::Client,
 }
@@ -19,5 +23,33 @@ impl NatsPublisherForTesting {
             .publish(subject, payload.into())
             .await
             .expect("should be able to publish");
+    }
+
+    /// Waits until the NATS server has processed everything published so far.
+    ///
+    /// A flush() only empties the client's write buffer, without waiting for
+    /// the server. This publishes a probe message to an inbox subscribed on
+    /// this same connection and waits for it to come back: the server handles
+    /// the commands of a connection in order, so receiving the probe implies
+    /// all earlier publishes were processed and routed to their subscribers.
+    pub async fn sync(&self) {
+        let inbox = self.client.new_inbox();
+        let mut probe_sub = self
+            .client
+            .subscribe(inbox.clone())
+            .await
+            .expect("should be able to subscribe to the probe inbox");
+        self.client
+            .publish(inbox, "".into())
+            .await
+            .expect("should be able to publish the probe");
+        self.client
+            .flush()
+            .await
+            .expect("should be able to flush the probe");
+        tokio::time::timeout(Duration::from_secs(5), probe_sub.next())
+            .await
+            .expect("should receive the probe back within 5 seconds")
+            .expect("should receive the probe back");
     }
 }

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -3,7 +3,7 @@
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use time::macros::format_description;
 use time::OffsetDateTime;
@@ -20,6 +20,7 @@ use shared::protobuf::ebpf_extractor::ebpf;
 use shared::protobuf::event::event::PeerObserverEvent;
 use shared::protobuf::event::Event;
 use shared::tokio::sync::watch;
+use shared::tokio::time::Instant;
 use shared::zstd;
 
 struct TrackingWriter {
@@ -245,6 +246,11 @@ impl Args {
     }
 }
 
+/// How long to wait for the NATS subscription to drain before shutting down
+/// anyway. Draining never completes while the NATS server is unreachable, as
+/// the client reconnects instead of processing the unsubscribe.
+pub const DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<()> {
     if args.archive_all() {
         log::info!("archiving all events: {}", args.archive_all());
@@ -279,6 +285,9 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
             .context("creating the initial archive file")?;
 
     let mut total_files: u64 = 0;
+    let mut draining = false;
+    // Only read once draining is set below.
+    let mut drain_deadline = Instant::now();
 
     loop {
         shared::tokio::select! {
@@ -307,20 +316,36 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
                     break; // subscription ended
                 }
             }
-            res = shutdown_rx.changed() => {
+            res = shutdown_rx.changed(), if !draining => {
                 match res {
                     Ok(_) => {
                         if *shutdown_rx.borrow() {
-                            log::info!("archiver tool received shutdown signal.");
-                            break;
+                            log::info!("archiver tool received shutdown signal. Draining the subscription.");
+                            draining = true;
                         }
                     }
                     Err(_) => {
                         // all senders dropped -> treat as shutdown
-                        log::warn!("The shutdown notification sender was dropped. Shutting down.");
-                        break;
+                        log::warn!("The shutdown notification sender was dropped. Draining the subscription.");
+                        draining = true;
                     }
                 }
+                if draining {
+                    // Unsubscribes, but keeps the subscription open until all
+                    // in-flight messages have been yielded. Afterwards,
+                    // sub.next() returns None and the loop above breaks.
+                    if let Err(e) = sub.drain().await {
+                        log::warn!("failed to drain the NATS subscription: {}. Shutting down.", e);
+                        break;
+                    }
+                    drain_deadline = Instant::now() + DRAIN_TIMEOUT;
+                }
+            }
+            // The deadline is absolute, so re-creating this future on every
+            // loop iteration doesn't extend it.
+            _ = shared::tokio::time::sleep_until(drain_deadline), if draining => {
+                log::warn!("draining the NATS subscription timed out. Shutting down anyway.");
+                break;
             }
         }
     }

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -19,7 +19,7 @@ use shared::protobuf::archive::ArchiveHeader;
 use shared::protobuf::ebpf_extractor::ebpf;
 use shared::protobuf::event::event::PeerObserverEvent;
 use shared::protobuf::event::Event;
-use shared::tokio::sync::watch;
+use shared::tokio::sync::{oneshot, watch};
 use shared::tokio::time::Instant;
 use shared::zstd;
 
@@ -251,7 +251,11 @@ impl Args {
 /// the client reconnects instead of processing the unsubscribe.
 pub const DRAIN_TIMEOUT: Duration = Duration::from_secs(10);
 
-pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<()> {
+pub async fn run(
+    args: Args,
+    mut shutdown_rx: watch::Receiver<bool>,
+    ready_tx: Option<oneshot::Sender<()>>,
+) -> Result<()> {
     if args.archive_all() {
         log::info!("archiving all events: {}", args.archive_all());
     } else {
@@ -283,6 +287,30 @@ pub async fn run(args: Args, mut shutdown_rx: watch::Receiver<bool>) -> Result<(
     let mut current_file =
         ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)
             .context("creating the initial archive file")?;
+
+    if let Some(ready_tx) = ready_tx {
+        // A flush only empties the client's write buffer and does not wait for
+        // the server to have processed the subscription. Prove the subscription
+        // is registered by publishing a probe to an inbox subscribed on this
+        // same connection: the server handles the commands of a connection in
+        // order, so receiving the probe back implies the earlier "*"
+        // subscription is active. The probe inbox contains dots, so it's not
+        // matched by the single-token "*" subscription.
+        let inbox = nc.new_inbox();
+        let mut probe_sub = nc
+            .subscribe(inbox.clone())
+            .await
+            .context("subscribing to the readiness probe inbox")?;
+        nc.publish(inbox, "".into())
+            .await
+            .context("publishing the readiness probe")?;
+        nc.flush().await.context("flushing the readiness probe")?;
+        probe_sub
+            .next()
+            .await
+            .context("receiving the readiness probe")?;
+        let _ = ready_tx.send(());
+    }
 
     let mut total_files: u64 = 0;
     let mut draining = false;

--- a/tools/archive/src/bin/archiver.rs
+++ b/tools/archive/src/bin/archiver.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
     simple_logger::init_with_level(args.log_level).context("could not initialize logger")?;
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
-    let mut archiver_handle = tokio::spawn(run(args, shutdown_rx));
+    let mut archiver_handle = tokio::spawn(run(args, shutdown_rx, None));
 
     tokio::select! {
         _ = signal::ctrl_c() => {

--- a/tools/archive/tests/integration.rs
+++ b/tools/archive/tests/integration.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "nats_integration_tests")]
 
-use archive::archiver::{run, Args};
+use archive::archiver::{run, Args, DRAIN_TIMEOUT};
 
 use archive::read::ArchiveReader;
 use shared::{
@@ -24,9 +24,17 @@ use shared::{
     },
     simple_logger,
     testing::{nats_publisher::NatsPublisherForTesting, nats_server::NatsServerForTesting},
-    tokio::{self, sync::watch, time::sleep},
+    tokio::{
+        self,
+        sync::{oneshot, watch},
+        task::JoinHandle,
+        time::sleep,
+    },
 };
-use std::{sync::Once, time::Duration};
+use std::{
+    sync::Once,
+    time::{Duration, Instant},
+};
 
 static INIT: Once = Once::new();
 
@@ -211,6 +219,22 @@ fn make_all_event_types() -> Vec<(Event, &'static str)> {
     events
 }
 
+async fn wait_for_archiver_ready(
+    ready_rx: oneshot::Receiver<()>,
+    archiver_handle: &mut JoinHandle<()>,
+) {
+    tokio::select! {
+        result = ready_rx => result.expect("archiver should send readiness signal"),
+        result = archiver_handle => {
+            result.unwrap();
+            unreachable!("archiver task exited before sending readiness signal");
+        }
+        _ = sleep(Duration::from_secs(5)) => {
+            panic!("timed out waiting for archiver readiness signal");
+        }
+    }
+}
+
 async fn run_filter_test(flag: &str, expected_count: usize) {
     setup();
 
@@ -220,10 +244,11 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (ready_tx, ready_rx) = oneshot::channel();
 
     let dir = tmp_dir.clone();
     let flag_owned = flag.to_string();
-    let archiver_handle = tokio::spawn(async move {
+    let mut archiver_handle = tokio::spawn(async move {
         let mut args = make_test_args(nats_server.port, &dir);
         match flag_owned.as_str() {
             "messages" => args.messages = true,
@@ -236,10 +261,10 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
             "ipc_extractor" => args.ipc_extractor = true,
             _ => {} // archive_all
         }
-        run(args, shutdown_rx).await.unwrap();
+        run(args, shutdown_rx, Some(ready_tx)).await.unwrap();
     });
 
-    sleep(Duration::from_secs(1)).await;
+    wait_for_archiver_ready(ready_rx, &mut archiver_handle).await;
 
     let all_events = make_all_event_types();
     for (event, _label) in &all_events {
@@ -248,7 +273,7 @@ async fn run_filter_test(flag: &str, expected_count: usize) {
             .await;
     }
 
-    sleep(Duration::from_millis(500)).await;
+    nats_publisher.sync().await;
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
@@ -318,16 +343,17 @@ async fn test_file_rotation_with_compression() {
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (ready_tx, ready_rx) = oneshot::channel();
 
     let dir = tmp_dir.clone();
-    let archiver_handle = tokio::spawn(async move {
+    let mut archiver_handle = tokio::spawn(async move {
         let mut args = make_test_args(nats_server.port, &dir);
         args.max_file_size = 1; // force rotation on every event
         args.compression_level = 1;
-        run(args, shutdown_rx).await.unwrap();
+        run(args, shutdown_rx, Some(ready_tx)).await.unwrap();
     });
 
-    sleep(Duration::from_secs(1)).await;
+    wait_for_archiver_ready(ready_rx, &mut archiver_handle).await;
 
     let all_events = make_all_event_types();
     for (event, _label) in &all_events {
@@ -336,7 +362,7 @@ async fn test_file_rotation_with_compression() {
             .await;
     }
 
-    sleep(Duration::from_millis(500)).await;
+    nats_publisher.sync().await;
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
@@ -388,14 +414,15 @@ async fn test_replayer_roundtrip() {
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (ready_tx, ready_rx) = oneshot::channel();
 
     let dir = tmp_dir.clone();
-    let archiver_handle = tokio::spawn(async move {
+    let mut archiver_handle = tokio::spawn(async move {
         let args = make_test_args(nats_server.port, &dir);
-        run(args, shutdown_rx).await.unwrap();
+        run(args, shutdown_rx, Some(ready_tx)).await.unwrap();
     });
 
-    sleep(Duration::from_secs(1)).await;
+    wait_for_archiver_ready(ready_rx, &mut archiver_handle).await;
 
     let all_events = make_all_event_types();
     for (event, _) in &all_events {
@@ -404,7 +431,7 @@ async fn test_replayer_roundtrip() {
             .await;
     }
 
-    sleep(Duration::from_millis(500)).await;
+    nats_publisher.sync().await;
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
@@ -438,15 +465,16 @@ async fn test_replayer_roundtrip_uncompressed() {
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (ready_tx, ready_rx) = oneshot::channel();
 
     let dir = tmp_dir.clone();
-    let archiver_handle = tokio::spawn(async move {
+    let mut archiver_handle = tokio::spawn(async move {
         let mut args = make_test_args(nats_server.port, &dir);
         args.compression_level = 0;
-        run(args, shutdown_rx).await.unwrap();
+        run(args, shutdown_rx, Some(ready_tx)).await.unwrap();
     });
 
-    sleep(Duration::from_secs(1)).await;
+    wait_for_archiver_ready(ready_rx, &mut archiver_handle).await;
 
     let all_events = make_all_event_types();
     for (event, _) in &all_events {
@@ -455,7 +483,7 @@ async fn test_replayer_roundtrip_uncompressed() {
             .await;
     }
 
-    sleep(Duration::from_millis(500)).await;
+    nats_publisher.sync().await;
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
@@ -485,15 +513,16 @@ async fn test_no_compression() {
     let nats_server = NatsServerForTesting::new(&[]).await;
     let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (ready_tx, ready_rx) = oneshot::channel();
 
     let dir = tmp_dir.clone();
-    let archiver_handle = tokio::spawn(async move {
+    let mut archiver_handle = tokio::spawn(async move {
         let mut args = make_test_args(nats_server.port, &dir);
         args.compression_level = 0;
-        run(args, shutdown_rx).await.unwrap();
+        run(args, shutdown_rx, Some(ready_tx)).await.unwrap();
     });
 
-    sleep(Duration::from_secs(1)).await;
+    wait_for_archiver_ready(ready_rx, &mut archiver_handle).await;
 
     let all_events = make_all_event_types();
     for (event, _) in &all_events {
@@ -502,7 +531,7 @@ async fn test_no_compression() {
             .await;
     }
 
-    sleep(Duration::from_millis(500)).await;
+    nats_publisher.sync().await;
     shutdown_tx.send(true).unwrap();
     archiver_handle.await.unwrap();
 
@@ -511,6 +540,48 @@ async fn test_no_compression() {
     assert!(!bin_files.is_empty(), ".0.bin file should exist");
     let zst_files = find_files(&tmp_dir, ".bin.zst");
     assert!(zst_files.is_empty(), ".0.bin.zst file should not exist");
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+/// The archiver must shut down even when the NATS server is gone. Draining an
+/// unreachable subscription never completes: the client reconnects instead of
+/// processing the unsubscribe, so the subscription is never closed.
+#[tokio::test]
+async fn test_shutdown_with_unreachable_nats() {
+    setup();
+
+    let tmp_dir = std::env::temp_dir().join("archiver_test_shutdown_unreachable");
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    // Keep ownership of the server here so it can be killed mid-test.
+    let nats_port = nats_server.port;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let dir = tmp_dir.clone();
+    let mut archiver_handle = tokio::spawn(async move {
+        let args = make_test_args(nats_port, &dir);
+        run(args, shutdown_rx, Some(ready_tx)).await.unwrap();
+    });
+
+    wait_for_archiver_ready(ready_rx, &mut archiver_handle).await;
+
+    // Kill the NATS server while the archiver is connected to it.
+    drop(nats_server);
+    sleep(Duration::from_millis(200)).await;
+
+    let start = Instant::now();
+    shutdown_tx.send(true).unwrap();
+    tokio::time::timeout(Duration::from_secs(20), archiver_handle)
+        .await
+        .expect("archiver should shut down without a reachable NATS server")
+        .unwrap();
+    assert!(
+        start.elapsed() >= DRAIN_TIMEOUT,
+        "archiver should exit through the drain timeout path"
+    );
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
 }


### PR DESCRIPTION
Follow-up for #439.

This replaces the fixed sleeps in the archive integration tests with explicit NATS synchronization

The archiver now sends an optional readiness signal after the NATS subscription is registered and the initial archive file is ready. The tests also use a NATS round-trip probe before shutdown, so they no longer rely on arbitrary delays to wait for published events to be processed.

This also drains the NATS subscription on shutdown, allowing in-flight messages to be yielded before the archive file is finalized

Tested on my fork CI:
https://github.com/octaviolucca/peer-observer/actions/runs/31206841457