### PR TITLE
add(archive): --low-data mode

### DIFF
--- a/protobuf/archive/header.proto
+++ b/protobuf/archive/header.proto
@@ -4,4 +4,7 @@ package header;
 
 message ArchiveHeader {
   required      uint64      created = 1;      // Timestamp (seconds since UNIX epoch) when the archive was created.
+  optional      bool        low_data = 2;     // Whether this archive was written in low-data mode. When true,
+                                              // raw transaction data was omitted from archived messages.
+                                              // Unset in archives written before this field existed.
 }

--- a/shared/src/protobuf/archive.rs
+++ b/shared/src/protobuf/archive.rs
@@ -7,10 +7,10 @@ use std::fmt;
 include!(concat!(env!("OUT_DIR"), "/header.rs"));
 
 impl ArchiveHeader {
-    pub fn new() -> Self {
+    pub fn new(low_data: bool) -> Self {
         Self {
             created: current_timestamp(),
-            low_data: Some(false),
+            low_data: Some(low_data),
         }
     }
 

--- a/shared/src/protobuf/archive.rs
+++ b/shared/src/protobuf/archive.rs
@@ -10,16 +10,46 @@ impl ArchiveHeader {
     pub fn new() -> Self {
         Self {
             created: current_timestamp(),
+            low_data: Some(false),
         }
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
         self.encode_length_delimited_to_vec()
     }
+
+    /// Unset in archives written before the field existed, which are full-data.
+    pub fn is_low_data(&self) -> bool {
+        self.low_data.unwrap_or(false)
+    }
 }
 
 impl fmt::Display for ArchiveHeader {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ArchiveHeader(created={})", self.created,)
+        write!(
+            f,
+            "ArchiveHeader(created={}, low_data={})",
+            self.created,
+            self.is_low_data()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_low_data_is_full_data() {
+        let header = ArchiveHeader {
+            created: 1,
+            low_data: None,
+        };
+
+        assert!(!header.is_low_data());
+        assert_eq!(
+            header.to_string(),
+            "ArchiveHeader(created=1, low_data=false)"
+        );
     }
 }

--- a/tools/archive/README.md
+++ b/tools/archive/README.md
@@ -31,6 +31,21 @@ Archive files are compressed with zstd using streaming compression — the write
 or `--compression-level 0` to skip compression. Rotation (`--max-file-size`) is checked against
 the compressed output stream. May overshoot slightly due to zstd internal buffering.
 
+### Low-data mode
+
+Raw transaction data makes up most of an archive. With `--low-data`, it is dropped before an
+event is written. `tx`, `blocktxn`, and prefilled transactions in `cmpctblock` keep their txid and
+wtxid. `block` messages keep only their header, including the block hash, and drop all block
+transactions.
+
+Everything else, including all connection, mempool and network metadata, is archived as usual. This
+makes it feasible to collect data over longer periods, at the cost of no longer being able to
+inspect the transactions and blocks themselves. Low-data mode requires `--messages`. It can be
+combined with other event filters, which are archived unchanged.
+
+Archives record the mode in their `ArchiveHeader`: `low_data` is `true` for low-data archives and
+`false` for complete ones. Archives written before the field existed are treated as full-data.
+
 ### Example
 
 Archive all events from a NATS server, rotating files at 100 MB, with zstd compression:
@@ -95,6 +110,8 @@ Options:
           If passed, archive ipc-extractor events
       --compression-level <COMPRESSION_LEVEL>
           Zstd compression level (0 = no compression, 1-22). Default: 22 (ultra) [default: 22]
+      --low-data
+          If passed, don't archive raw transaction data. Requires --messages. Other enabled event filters are archived unchanged. Transactions keep their txid and wtxid. Blocks keep only their header
   -h, --help
           Print help
   -V, --version

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -491,3 +491,199 @@ fn format_utc_timestamp(epoch_ms: u64) -> String {
         .format(&fmt)
         .expect("timestamp formatting failed")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use shared::protobuf::bitcoin_primitives::{BlockHeader, PrefilledTransaction, Transaction};
+    use shared::protobuf::ebpf_extractor::message::{
+        Block, BlockTxn, CompactBlock, Inv, MessageEvent, Metadata, Tx,
+    };
+    use shared::protobuf::ebpf_extractor::Ebpf;
+
+    const TXID: [u8; 32] = [0x11; 32];
+    const WTXID: [u8; 32] = [0x22; 32];
+    const TXID_2: [u8; 32] = [0x44; 32];
+    const WTXID_2: [u8; 32] = [0x55; 32];
+    const BLOCK_HASH: [u8; 32] = [0x33; 32];
+
+    fn transaction() -> Transaction {
+        transaction_with_ids(TXID, WTXID, 0xff)
+    }
+
+    fn transaction_with_ids(txid: [u8; 32], wtxid: [u8; 32], raw_byte: u8) -> Transaction {
+        Transaction {
+            txid: txid.to_vec(),
+            wtxid: wtxid.to_vec(),
+            raw: Some(vec![raw_byte; 500]),
+        }
+    }
+
+    fn block_header() -> BlockHeader {
+        BlockHeader {
+            version: 1,
+            prev_blockhash: vec![0u8; 32],
+            merkle_root: vec![0u8; 32],
+            time: 1234,
+            bits: 5678,
+            nonce: 42,
+            hash: BLOCK_HASH.to_vec(),
+        }
+    }
+
+    fn message_event(msg: Msg) -> Event {
+        Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+            ebpf_event: Some(ebpf::EbpfEvent::Message(MessageEvent {
+                meta: Metadata {
+                    peer_id: 0,
+                    addr: "127.0.0.1:8333".to_string(),
+                    conn_type: 1,
+                    command: String::new(),
+                    inbound: true,
+                    size: 0,
+                },
+                msg: Some(msg),
+            })),
+        }))
+        .unwrap()
+    }
+
+    /// Returns the P2P message of an event, panicking if there is none.
+    fn msg_of(event: &Event) -> &Msg {
+        match event.peer_observer_event.as_ref().unwrap() {
+            PeerObserverEvent::EbpfExtractor(ebpf) => match ebpf.ebpf_event.as_ref().unwrap() {
+                ebpf::EbpfEvent::Message(message_event) => message_event.msg.as_ref().unwrap(),
+                _ => panic!("expected a P2P message event"),
+            },
+            _ => panic!("expected an ebpf event"),
+        }
+    }
+
+    fn parse_args(args: &[&str]) -> std::result::Result<Args, clap::Error> {
+        let mut argv = vec!["archiver", "--output-dir", "/tmp"];
+        argv.extend_from_slice(args);
+        Args::try_parse_from(argv)
+    }
+
+    #[test]
+    fn low_data_requires_messages() {
+        assert!(parse_args(&["--low-data"]).is_err());
+        assert!(parse_args(&["--low-data", "--messages"]).is_ok());
+        assert!(parse_args(&["--low-data", "--messages", "--connections"]).is_ok());
+    }
+
+    #[test]
+    fn low_data_strips_tx_raw_and_keeps_ids() {
+        let mut event = message_event(Msg::Tx(Tx { tx: transaction() }));
+
+        strip_low_data(&mut event);
+
+        let Msg::Tx(tx) = msg_of(&event) else {
+            panic!("expected a tx message");
+        };
+        assert_eq!(tx.tx.raw, None);
+        assert_eq!(tx.tx.txid, TXID.to_vec());
+        assert_eq!(tx.tx.wtxid, WTXID.to_vec());
+    }
+
+    #[test]
+    fn low_data_keeps_block_header_and_removes_transactions() {
+        let mut event = message_event(Msg::Block(Block {
+            header: block_header(),
+            transactions: vec![transaction(), transaction()],
+        }));
+
+        strip_low_data(&mut event);
+
+        let Msg::Block(block) = msg_of(&event) else {
+            panic!("expected a block message");
+        };
+        assert_eq!(block.header.hash, BLOCK_HASH.to_vec());
+        assert_eq!(block.header.nonce, 42);
+        assert!(block.transactions.is_empty());
+    }
+
+    #[test]
+    fn low_data_strips_blocktxn_transaction_raw() {
+        let mut event = message_event(Msg::Blocktxn(BlockTxn {
+            block_hash: BLOCK_HASH.to_vec(),
+            transactions: vec![transaction(), transaction()],
+        }));
+
+        strip_low_data(&mut event);
+
+        let Msg::Blocktxn(blocktxn) = msg_of(&event) else {
+            panic!("expected a blocktxn message");
+        };
+        assert_eq!(blocktxn.block_hash, BLOCK_HASH.to_vec());
+        assert_eq!(blocktxn.transactions.len(), 2);
+        for tx in &blocktxn.transactions {
+            assert_eq!(tx.raw, None);
+            assert_eq!(tx.txid, TXID.to_vec());
+            assert_eq!(tx.wtxid, WTXID.to_vec());
+        }
+    }
+
+    #[test]
+    fn low_data_strips_compactblock_prefilled_transaction_raw() {
+        let mut event = message_event(Msg::Compactblock(CompactBlock {
+            header: block_header(),
+            nonce: 7,
+            short_ids: vec![vec![0xaa; 6]],
+            transactions: vec![
+                PrefilledTransaction {
+                    diff_index: 0,
+                    tx: transaction(),
+                },
+                PrefilledTransaction {
+                    diff_index: 2,
+                    tx: transaction_with_ids(TXID_2, WTXID_2, 0xee),
+                },
+            ],
+        }));
+
+        strip_low_data(&mut event);
+
+        let Msg::Compactblock(compact_block) = msg_of(&event) else {
+            panic!("expected a compactblock message");
+        };
+        assert_eq!(compact_block.nonce, 7);
+        assert_eq!(compact_block.short_ids, vec![vec![0xaa; 6]]);
+        assert_eq!(compact_block.header.hash, BLOCK_HASH.to_vec());
+        assert_eq!(compact_block.transactions.len(), 2);
+        assert_eq!(compact_block.transactions[0].diff_index, 0);
+        assert_eq!(compact_block.transactions[0].tx.raw, None);
+        assert_eq!(compact_block.transactions[0].tx.txid, TXID.to_vec());
+        assert_eq!(compact_block.transactions[0].tx.wtxid, WTXID.to_vec());
+        assert_eq!(compact_block.transactions[1].diff_index, 2);
+        assert_eq!(compact_block.transactions[1].tx.raw, None);
+        assert_eq!(compact_block.transactions[1].tx.txid, TXID_2.to_vec());
+        assert_eq!(compact_block.transactions[1].tx.wtxid, WTXID_2.to_vec());
+    }
+
+    #[test]
+    fn low_data_leaves_other_messages_untouched() {
+        let mut event = message_event(Msg::Inv(Inv { items: vec![] }));
+        let before = event.encode_to_vec();
+
+        strip_low_data(&mut event);
+
+        assert_eq!(event.encode_to_vec(), before);
+    }
+
+    #[test]
+    fn low_data_leaves_non_p2p_events_untouched() {
+        let mut event = Event::new(PeerObserverEvent::RpcExtractor(
+            shared::protobuf::rpc_extractor::Rpc {
+                rpc_event: Some(shared::protobuf::rpc_extractor::rpc::RpcEvent::Uptime(1234)),
+            },
+        ))
+        .unwrap();
+        let before = event.encode_to_vec();
+
+        strip_low_data(&mut event);
+
+        assert_eq!(event.encode_to_vec(), before);
+    }
+}

--- a/tools/archive/src/archiver/mod.rs
+++ b/tools/archive/src/archiver/mod.rs
@@ -17,6 +17,7 @@ use shared::nats_util;
 use shared::prost::Message;
 use shared::protobuf::archive::ArchiveHeader;
 use shared::protobuf::ebpf_extractor::ebpf;
+use shared::protobuf::ebpf_extractor::message::message_event::Msg;
 use shared::protobuf::event::event::PeerObserverEvent;
 use shared::protobuf::event::Event;
 use shared::tokio::sync::{oneshot, watch};
@@ -106,7 +107,12 @@ struct ArchiveFile {
 }
 
 impl ArchiveFile {
-    fn new(output_dir: &Path, base_name: &str, compression_level: u32) -> std::io::Result<Self> {
+    fn new(
+        output_dir: &Path,
+        base_name: &str,
+        compression_level: u32,
+        low_data: bool,
+    ) -> std::io::Result<Self> {
         let ext = if compression_level > 0 {
             "bin.zst"
         } else {
@@ -139,7 +145,7 @@ impl ArchiveFile {
             }
         };
         let mut writer = ArchiveWriter::new(file, compression_level)?;
-        let header_bytes = ArchiveHeader::new().to_bytes();
+        let header_bytes = ArchiveHeader::new(low_data).to_bytes();
         writer.write_all(&header_bytes)?;
         writer.flush()?;
 
@@ -230,6 +236,12 @@ pub struct Args {
     /// Zstd compression level (0 = no compression, 1-22). Default: 22 (ultra).
     #[arg(long, default_value_t = 22)]
     pub compression_level: u32,
+
+    /// If passed, don't archive raw transaction data.
+    /// Requires --messages. Other enabled event filters are archived unchanged.
+    /// Transactions keep their txid and wtxid. Blocks keep only their header.
+    #[arg(long, requires = "messages")]
+    pub low_data: bool,
 }
 
 impl Args {
@@ -269,6 +281,7 @@ pub async fn run(
         log::info!("archiving log_extractor events: {}", args.log_extractor);
         log::info!("archiving ipc_extractor events: {}", args.ipc_extractor);
     }
+    log::info!("archiving in low-data mode: {}", args.low_data);
 
     let nc = nats_util::prepare_connection(&args.nats)
         .context("preparing NATS connection")?
@@ -284,9 +297,13 @@ pub async fn run(
 
     fs::create_dir_all(&args.output_dir)
         .with_context(|| format!("creating output directory {}", args.output_dir.display()))?;
-    let mut current_file =
-        ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)
-            .context("creating the initial archive file")?;
+    let mut current_file = ArchiveFile::new(
+        &args.output_dir,
+        &args.base_name,
+        args.compression_level,
+        args.low_data,
+    )
+    .context("creating the initial archive file")?;
 
     if let Some(ready_tx) = ready_tx {
         // A flush only empties the client's write buffer and does not wait for
@@ -321,7 +338,7 @@ pub async fn run(
         shared::tokio::select! {
             maybe_msg = sub.next() => {
                 if let Some(msg) = maybe_msg {
-                    let event = match Event::decode(msg.payload.as_ref()) {
+                    let mut event = match Event::decode(msg.payload.as_ref()) {
                         Ok(event) => event,
                         Err(e) => {
                             log::warn!("failed to decode event: {}, skipping", e);
@@ -329,6 +346,10 @@ pub async fn run(
                         }
                     };
                     if should_archive(&event, &args){
+                        if args.low_data {
+                            strip_low_data(&mut event);
+                        }
+
                         if let Err(e) = current_file.write_event(&event) {
                             log::error!("failed to write event: {}", e);
                             break;
@@ -391,8 +412,43 @@ pub async fn run(
 fn rotate(current_file: ArchiveFile, args: &Args) -> std::io::Result<ArchiveFile> {
     log::trace!("rotating {:?}", current_file.path);
     current_file.finalize()?;
-    let new_file = ArchiveFile::new(&args.output_dir, &args.base_name, args.compression_level)?;
+    let new_file = ArchiveFile::new(
+        &args.output_dir,
+        &args.base_name,
+        args.compression_level,
+        args.low_data,
+    )?;
     Ok(new_file)
+}
+
+/// Removes the bulk of a P2P message: the raw bytes of transactions and the
+/// transactions of a block. Transactions keep their txid and wtxid, blocks keep
+/// their header, which includes the block hash.
+/// Messages that carry no transaction payloads are left untouched.
+fn strip_low_data(event: &mut Event) {
+    let Some(PeerObserverEvent::EbpfExtractor(ebpf)) = event.peer_observer_event.as_mut() else {
+        return;
+    };
+    let Some(ebpf::EbpfEvent::Message(message_event)) = ebpf.ebpf_event.as_mut() else {
+        return;
+    };
+    let Some(msg) = message_event.msg.as_mut() else {
+        return;
+    };
+
+    match msg {
+        Msg::Tx(tx) => tx.tx.raw = None,
+        Msg::Block(block) => block.transactions.clear(),
+        Msg::Blocktxn(blocktxn) => blocktxn
+            .transactions
+            .iter_mut()
+            .for_each(|tx| tx.raw = None),
+        Msg::Compactblock(compact_block) => compact_block
+            .transactions
+            .iter_mut()
+            .for_each(|prefilled| prefilled.tx.raw = None),
+        _ => (),
+    }
 }
 
 fn should_archive(event: &Event, args: &Args) -> bool {

--- a/tools/archive/tests/integration.rs
+++ b/tools/archive/tests/integration.rs
@@ -77,6 +77,7 @@ fn make_test_args(nats_port: u16, output_dir: &std::path::Path) -> Args {
         log_extractor: false,
         ipc_extractor: false,
         compression_level: 3,
+        low_data: false,
     }
 }
 

--- a/tools/archive/tests/integration.rs
+++ b/tools/archive/tests/integration.rs
@@ -9,6 +9,7 @@ use shared::{
     nats_util,
     prost::Message,
     protobuf::{
+        bitcoin_primitives,
         ebpf_extractor::{
             connection::{self, Connection, InboundConnection},
             ebpf,
@@ -585,4 +586,155 @@ async fn test_shutdown_with_unreachable_nats() {
     );
 
     let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+/// Publishes a tx and a block message and returns the archived events.
+async fn archive_tx_and_block(low_data: bool, tmp_dir: &std::path::Path) -> Vec<Event> {
+    setup();
+
+    let _ = std::fs::remove_dir_all(tmp_dir);
+
+    let nats_server = NatsServerForTesting::new(&[]).await;
+    let nats_publisher = NatsPublisherForTesting::new(nats_server.port).await;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    let dir = tmp_dir.to_path_buf();
+    let mut archiver_handle = tokio::spawn(async move {
+        let mut args = make_test_args(nats_server.port, &dir);
+        args.low_data = low_data;
+        args.messages = low_data;
+        run(args, shutdown_rx, Some(ready_tx)).await.unwrap();
+    });
+
+    wait_for_archiver_ready(ready_rx, &mut archiver_handle).await;
+
+    let transaction = bitcoin_primitives::Transaction {
+        txid: vec![0x11; 32],
+        wtxid: vec![0x22; 32],
+        raw: Some(vec![0xff; 500]),
+    };
+    let header = bitcoin_primitives::BlockHeader {
+        version: 1,
+        prev_blockhash: vec![0u8; 32],
+        merkle_root: vec![0u8; 32],
+        time: 1234,
+        bits: 5678,
+        nonce: 42,
+        hash: vec![0x33; 32],
+    };
+    let events = [
+        Msg::Tx(message::Tx {
+            tx: transaction.clone(),
+        }),
+        Msg::Block(message::Block {
+            header,
+            transactions: vec![transaction],
+        }),
+    ]
+    .map(|msg| {
+        Event::new(PeerObserverEvent::EbpfExtractor(Ebpf {
+            ebpf_event: Some(ebpf::EbpfEvent::Message(message::MessageEvent {
+                meta: Metadata {
+                    peer_id: 0,
+                    addr: "127.0.0.1:8333".to_string(),
+                    conn_type: 1,
+                    command: String::new(),
+                    inbound: true,
+                    size: 0,
+                },
+                msg: Some(msg),
+            })),
+        }))
+        .unwrap()
+    });
+
+    for event in &events {
+        nats_publisher
+            .publish(Subject::NetMsg.to_string(), event.encode_to_vec())
+            .await;
+    }
+
+    nats_publisher.sync().await;
+    shutdown_tx.send(true).unwrap();
+    archiver_handle.await.unwrap();
+
+    let archive_path = find_files(tmp_dir, ".bin.zst")
+        .into_iter()
+        .next()
+        .expect("expected a .<timestamp>.bin.zst file");
+    let archive = ArchiveReader::open(&archive_path).unwrap();
+    assert_eq!(
+        archive.header.low_data,
+        Some(low_data),
+        "the archive header should record the low-data mode"
+    );
+
+    archive.map(|event| event.unwrap()).collect()
+}
+
+#[tokio::test]
+async fn test_low_data_strips_transaction_raw_and_block_transactions() {
+    let tmp_dir = std::env::temp_dir().join("archiver_test_low_data");
+    let archived = archive_tx_and_block(true, &tmp_dir).await;
+
+    let [tx_event, block_event] = &archived[..] else {
+        panic!("expected a tx and a block event, got {}", archived.len());
+    };
+
+    let Msg::Tx(tx) = msg_of(tx_event) else {
+        panic!("expected a tx message");
+    };
+    assert_eq!(tx.tx.raw, None, "raw transaction data should be stripped");
+    assert_eq!(tx.tx.txid, vec![0x11; 32], "the txid should be kept");
+    assert_eq!(tx.tx.wtxid, vec![0x22; 32], "the wtxid should be kept");
+
+    let Msg::Block(block) = msg_of(block_event) else {
+        panic!("expected a block message");
+    };
+    assert_eq!(
+        block.header.hash,
+        vec![0x33; 32],
+        "the block header should be kept"
+    );
+    assert!(
+        block.transactions.is_empty(),
+        "block transactions should be removed in low-data mode"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[tokio::test]
+async fn test_without_low_data_transaction_and_block_data_are_archived() {
+    let tmp_dir = std::env::temp_dir().join("archiver_test_full_data");
+    let archived = archive_tx_and_block(false, &tmp_dir).await;
+
+    let [tx_event, block_event] = &archived[..] else {
+        panic!("expected a tx and a block event, got {}", archived.len());
+    };
+
+    let Msg::Tx(tx) = msg_of(tx_event) else {
+        panic!("expected a tx message");
+    };
+    assert_eq!(tx.tx.raw, Some(vec![0xff; 500]));
+
+    let Msg::Block(block) = msg_of(block_event) else {
+        panic!("expected a block message");
+    };
+    assert_eq!(block.transactions.len(), 1);
+    assert_eq!(block.transactions[0].raw, Some(vec![0xff; 500]));
+
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+/// Returns the P2P message of an event, panicking if there is none.
+fn msg_of(event: &Event) -> &Msg {
+    match event.peer_observer_event.as_ref().unwrap() {
+        PeerObserverEvent::EbpfExtractor(ebpf) => match ebpf.ebpf_event.as_ref().unwrap() {
+            ebpf::EbpfEvent::Message(message_event) => message_event.msg.as_ref().unwrap(),
+            _ => panic!("expected a P2P message event"),
+        },
+        _ => panic!("expected an ebpf event"),
+    }
 }

--- a/tools/archive/tests/replayer.rs
+++ b/tools/archive/tests/replayer.rs
@@ -21,7 +21,11 @@ fn test_event() -> Event {
 }
 
 fn archive_bytes(events: &[Event]) -> Vec<u8> {
-    let mut bytes = ArchiveHeader { created: 1 }.encode_length_delimited_to_vec();
+    let mut bytes = ArchiveHeader {
+        created: 1,
+        low_data: None,
+    }
+    .encode_length_delimited_to_vec();
     for event in events {
         bytes.extend(event.encode_length_delimited_to_vec());
     }
@@ -80,7 +84,11 @@ fn missing_header_is_an_archive_error() {
 
 #[test]
 fn truncated_event_is_an_unexpected_eof() {
-    let mut bytes = ArchiveHeader { created: 1 }.encode_length_delimited_to_vec();
+    let mut bytes = ArchiveHeader {
+        created: 1,
+        low_data: None,
+    }
+    .encode_length_delimited_to_vec();
     let mut event_bytes = test_event().encode_length_delimited_to_vec();
     event_bytes.pop();
     bytes.extend(event_bytes);
@@ -95,7 +103,11 @@ fn truncated_event_is_an_unexpected_eof() {
 
 #[test]
 fn malformed_event_is_a_read_error() {
-    let mut bytes = ArchiveHeader { created: 1 }.encode_length_delimited_to_vec();
+    let mut bytes = ArchiveHeader {
+        created: 1,
+        low_data: None,
+    }
+    .encode_length_delimited_to_vec();
     bytes.push(1);
     bytes.push(0xff);
     let path = write_temp_archive("malformed_event", bytes);


### PR DESCRIPTION
Follow-up for #439.

This adds a `--low-data` mode to the archive tool. When enabled, the archiver drops large raw transaction/block payloads before writing events to disk:

- `tx` messages keep `txid` and `wtxid`, but drop raw transaction bytes
- `block` messages keep the block header/hash, but drop full transactions
- `blocktxn` messages keep the block hash and transaction ids, but drop raw transaction bytes
- compact block prefilled transactions keep transaction ids, but drop raw transaction bytes

Archives now record the selected mode in `ArchiveHeader.low_data`, so readers can distinguish older archives where the field is unset from new full-data and low-data archives.

I ran local mainnet comparisons on my node:

4h25m window:
- full-data: 88.68 MiB
- low-data: 55.79 MiB
- compressed size reduction: 37.1%

My local run did not capture `blocktxn` or compact block prefilled transactions yet. I’ll run a separate comparison for those and update this PR with the results.

CI passed on my fork:
https://github.com/octaviolucca/peer-observer/actions/runs/32035017742